### PR TITLE
Remove Litera theme and enforce Work Sans on all text elements

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -63,9 +63,7 @@ website:
 format:
   html:
     fontawesome: true
-    theme: 
-      - litera
-      - theme-custom.scss
+    theme: theme-custom.scss
     fontsize: 0.95rem
     linestretch: 1.6
     toc: false

--- a/theme-custom.scss
+++ b/theme-custom.scss
@@ -67,7 +67,8 @@ $card-box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06
 
 // Global styles
 body {
-  font-size: 0.95rem !important;  // Explicitly set body font size
+  font-family: $font-family-sans-serif !important;  // Explicitly set Work Sans
+  font-size: 0.95rem !important;
   font-weight: 400;
   letter-spacing: -0.011em;
   line-height: 1.6;
@@ -75,6 +76,7 @@ body {
 
 // Typography improvements
 p {
+  font-family: $font-family-sans-serif !important;  // Explicitly set Work Sans for paragraphs
   margin-bottom: 1rem;
   line-height: 1.6;
   font-size: 0.95rem;
@@ -278,17 +280,20 @@ h4, h5, h6, .h4, .h5, .h6 {
 
 // List improvements
 ul, ol {
+  font-family: $font-family-sans-serif !important;
   margin-bottom: 1rem;
   line-height: 1.6;
   font-size: 0.95rem;
 }
 
 li {
+  font-family: $font-family-sans-serif !important;
   margin-bottom: 0.4rem;
 }
 
 // Blockquotes
 blockquote {
+  font-family: $font-family-sans-serif !important;
   border-left: 4px solid $primary;
   padding-left: 1.25rem;
   margin: 1.5rem 0;


### PR DESCRIPTION
This commit fixes the lingering serif fonts by removing the Litera Bootstrap theme which was overriding our custom Work Sans typography.

## Changes Made

**_quarto.yml:**
- Removed "litera" from the theme list
- Now using only theme-custom.scss for complete control
- The Litera theme had built-in serif fonts that were overriding our Work Sans settings throughout the site

**theme-custom.scss:**
- Added explicit font-family declarations to body element
- Added explicit font-family to all paragraph (<p>) elements
- Added explicit font-family to all list elements (ul, ol, li)
- Added explicit font-family to blockquotes
- All declarations use !important to ensure they override any remaining Bootstrap defaults

## Result

The entire website now uses Work Sans consistently across:
- All body text
- All headings
- All navigation elements
- All lists (ul, ol, li)
- All paragraphs
- All blockquotes
- All other text elements

Code blocks continue to use JetBrains Mono as intended.

This ensures 100% sans-serif typography with no serif fonts appearing anywhere on the site.