### PR TITLE
Fix site-url and repo-url to match repository name

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -6,8 +6,8 @@ website:
   title: "Cresko Laboratory"
   description: "An evolutionary genomics laboratory at the University of Oregon"
   favicon: files/images/favicon.ico
-  site-url: https://wcresko.github.io/
-  repo-url: https://github.com/wcresko/wcresko.github.io
+  site-url: https://wcresko.github.io/Cresko_Lab_Website/
+  repo-url: https://github.com/wcresko/Cresko_Lab_Website
   page-navigation: true
   
   navbar:


### PR DESCRIPTION
Updated URLs to use Cresko_Lab_Website instead of wcresko.github.io to correctly configure GitHub Pages for this repository.